### PR TITLE
Fix SeaExplorer L0 timeseries name to avoid broken website links

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -400,7 +400,7 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, kind='raw',
     except:
         pass
     id0 = ds.attrs['deployment_name']
-    outname = outdir + id0 +  '_L0.nc'
+    outname = outdir + id0 +  '.nc'
     _log.info('writing %s', outname)
     ds.to_netcdf(outname, 'w')
 


### PR DESCRIPTION
Removed _L0 from the end of the SeaExplorer L0 timeseries name for the netcdf files. This change makes the filename consistent with the L0 timeseries filename for the Slocums, and avoids creating broken website links, since the html template is looking for a filename without L0 appended to the end. 