### PR TITLE
catch invalid datetimes in AD2CP_TIME

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -111,6 +111,8 @@ def raw_to_rawnc(indir, outdir, deploymentyaml, incremental=True, min_samples_in
                                             dayfirst=True)
                     # If AD2CP data present, convert the timestamps to datetime type
                     if 'AD2CP_TIME' in out.columns:
+                        # Set datestamps with date 00000 to None to prevent datetime error
+                        out.loc[out.AD2CP_TIME.str[:6]=='000000','AD2CP_TIME'] = None
                         out['AD2CP_TIME'] = pd.to_datetime(out.AD2CP_TIME)
                     with out.to_xarray() as outx:
 


### PR DESCRIPTION
At the beginning of some missions, we get timestamps from AD2CP_TIME before it has synced it's clock. These are:

00000000 00:00:00

Passing one of these to pd.to_datetime to parse the dates throws an error

`ValueError: year 0 is out of range`

This addition checks for timestamps starting 000000 and replaces them with None, which pd.to_datetime then converts to NaT