### PR TITLE
changed all print to log.info or log.debug

### DIFF
--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -116,9 +116,9 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
 
     ds = xr.open_dataset(inname, decode_times=False)
     _log.info(f'Working on: {inname}')
-    _log.debug(ds)
-    _log.debug(ds.time[0])
-    _log.debug(ds.time[-1])
+    _log.debug(str(ds))
+    _log.debug(str(ds.time[0]))
+    _log.debug(str(ds.time[-1]))
 
 
     profiles = np.unique(ds.profile_index)
@@ -181,7 +181,7 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
                         values=ds[k].values[good], statistic='mean',
                         bins=[profile_bins, depth_bins])
 
-            _log.debug('dat', np.shape(dat))
+            _log.debug(f'dat{np.shape(dat)}')
             dsout[k] = (('depth', 'time'), dat.T, ds[k].attrs)
 
             # fill gaps in data:
@@ -190,7 +190,7 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
     # fix u and v, because they should really not be gridded...
     if (('water_velocity_eastward' in dsout.keys()) and
             ('u' in profile_meta.keys())):
-        _log.debug(ds.water_velocity_eastward)
+        _log.debug(str(ds.water_velocity_eastward))
         dsout['u'] = dsout.water_velocity_eastward.mean(axis=0)
         dsout['u'].attrs = profile_meta['u']
         dsout['v'] = dsout.water_velocity_northward.mean(axis=0)

--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -115,10 +115,10 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
     profile_meta = deployment['profile_variables']
 
     ds = xr.open_dataset(inname, decode_times=False)
-    print('Working on:')
-    print(ds)
-    print(ds.time[0])
-    print(ds.time[-1])
+    _log.info(f'Working on: {inname}')
+    _log.debug(ds)
+    _log.debug(ds.time[0])
+    _log.debug(ds.time[-1])
 
 
     profiles = np.unique(ds.profile_index)
@@ -181,7 +181,7 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
                         values=ds[k].values[good], statistic='mean',
                         bins=[profile_bins, depth_bins])
 
-            print('dat', np.shape(dat))
+            _log.debug('dat', np.shape(dat))
             dsout[k] = (('depth', 'time'), dat.T, ds[k].attrs)
 
             # fill gaps in data:
@@ -190,7 +190,7 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
     # fix u and v, because they should really not be gridded...
     if (('water_velocity_eastward' in dsout.keys()) and
             ('u' in profile_meta.keys())):
-        print(ds.water_velocity_eastward)
+        _log.debug(ds.water_velocity_eastward)
         dsout['u'] = dsout.water_velocity_eastward.mean(axis=0)
         dsout['u'].attrs = profile_meta['u']
         dsout['v'] = dsout.water_velocity_northward.mean(axis=0)

--- a/pyglider/plotting.py
+++ b/pyglider/plotting.py
@@ -32,7 +32,7 @@ def _autoclim(vals):
     d = m85 - m15
     m15 = m15 - d / 10
     m85 = m85 + d / 10
-    print('m15, m85', m15, m85, np.max((min, m15)))
+    _log.info('m15, m85', m15, m85, np.max((min, m15)))
     return np.max((min, m15)), np.min((max, m85))
 
 def timeseries_plots(fname, plottingyaml):
@@ -43,7 +43,7 @@ def timeseries_plots(fname, plottingyaml):
             starttime = np.datetime64(config['starttime'])
         else:
             starttime = None
-        print('starttime:', starttime)
+        _log.info('starttime:', starttime)
 
     try:
         os.mkdir(config['figdir'])
@@ -78,7 +78,7 @@ def timeseries_plots(fname, plottingyaml):
                                     sharex=True, sharey=False)
             axs = axs.flat
             for n, k in enumerate(keys):
-                print('key', k)
+                _log.debug('key', k)
                 if config['timeseries'][k] == 'True':
                     ax = axs[n]
                     good = np.where(~np.isnan(ds[k]))[0]
@@ -98,7 +98,7 @@ def timeseries_plots(fname, plottingyaml):
             _log.info('Plotting colorline data')
 
             for n, k in enumerate(keys):
-                print('key', k)
+                _log.debug('key', k)
                 ax = axs[n]
                 locator = mdates.AutoDateLocator(minticks=3, maxticks=7)
                 formatter = mdates.ConciseDateFormatter(locator)
@@ -200,7 +200,7 @@ def add_suptitle(fig, ds):
 
 
 def grid_plots(fname, plottingyaml):
-    print('Gird plots!')
+    _log.info('Gird plots!')
     with open(plottingyaml) as fin:
         config = yaml.safe_load(fin)
         if 'starttime' in config.keys():
@@ -215,7 +215,7 @@ def grid_plots(fname, plottingyaml):
 
     with xr.open_dataset(fname, decode_times=True) as ds0:
         ds = ds0.sel(time=slice(starttime, None))
-        print(ds)
+        _log.debug(ds)
 
         keys = config['pcolor']['vars'].keys()
         N = len(keys)
@@ -227,10 +227,10 @@ def grid_plots(fname, plottingyaml):
                                 sharex=True, sharey=True)
         axs = axs.flat
         for n, k in enumerate(keys):
-            print('key', k)
+            _log.debug('key', k)
 
             pconf = config['pcolor']['vars'][k]
-            print(pconf)
+            _log.debug(pconf)
             cmap = pconf.get('cmap', 'viridis')
             vmin = pconf.get('vmin', None)
             vmax = pconf.get('vmax', None)
@@ -249,8 +249,8 @@ def grid_plots(fname, plottingyaml):
             # make time windows:
             # get good profiles.  i.e. those w data
             ind = np.where(np.sum(np.isfinite(ds[k].values), axis=0)>10)[0]
-            print(ind)
-            print(len(ds.time))
+            _log.debug(ind)
+            _log.debug(len(ds.time))
             if len(ind) > 1:
                 time = ds.time[ind[1:]] + np.diff(ds.time[ind]) / 2
                 time = np.hstack((time[0] - (time[1]-time[0]) / 2, time))
@@ -261,7 +261,7 @@ def grid_plots(fname, plottingyaml):
                 ax.contour(ds.time[ind], ds.depth, ds.potential_density[:, ind], colors='0.5',
                        levels=np.arange(22, 28, 0.5)+1000, linewidths=0.5, alpha=0.7)
 
-                print(ds[k])
+                _log.debug(ds[k])
 
                 fig.colorbar(pc, ax=ax, extend='both', shrink=0.6)
             ax.set_title(ds[k].attrs['long_name'] + ' [' +

--- a/pyglider/plotting.py
+++ b/pyglider/plotting.py
@@ -32,7 +32,7 @@ def _autoclim(vals):
     d = m85 - m15
     m15 = m15 - d / 10
     m85 = m85 + d / 10
-    _log.info('m15, m85', m15, m85, np.max((min, m15)))
+    _log.info(f'm15, m85 {m15}, {m85}, {np.max((min, m15))}')
     return np.max((min, m15)), np.min((max, m85))
 
 def timeseries_plots(fname, plottingyaml):
@@ -43,7 +43,7 @@ def timeseries_plots(fname, plottingyaml):
             starttime = np.datetime64(config['starttime'])
         else:
             starttime = None
-        _log.info('starttime:', starttime)
+        _log.info(f'starttime: {starttime}')
 
     try:
         os.mkdir(config['figdir'])
@@ -78,7 +78,7 @@ def timeseries_plots(fname, plottingyaml):
                                     sharex=True, sharey=False)
             axs = axs.flat
             for n, k in enumerate(keys):
-                _log.debug('key', k)
+                _log.debug(f'key {k}')
                 if config['timeseries'][k] == 'True':
                     ax = axs[n]
                     good = np.where(~np.isnan(ds[k]))[0]
@@ -98,7 +98,7 @@ def timeseries_plots(fname, plottingyaml):
             _log.info('Plotting colorline data')
 
             for n, k in enumerate(keys):
-                _log.debug('key', k)
+                _log.debug(f'key, {k}')
                 ax = axs[n]
                 locator = mdates.AutoDateLocator(minticks=3, maxticks=7)
                 formatter = mdates.ConciseDateFormatter(locator)
@@ -200,7 +200,7 @@ def add_suptitle(fig, ds):
 
 
 def grid_plots(fname, plottingyaml):
-    _log.info('Gird plots!')
+    _log.info('Grid plots!')
     with open(plottingyaml) as fin:
         config = yaml.safe_load(fin)
         if 'starttime' in config.keys():
@@ -215,7 +215,7 @@ def grid_plots(fname, plottingyaml):
 
     with xr.open_dataset(fname, decode_times=True) as ds0:
         ds = ds0.sel(time=slice(starttime, None))
-        _log.debug(ds)
+        _log.debug(str(ds))
 
         keys = config['pcolor']['vars'].keys()
         N = len(keys)
@@ -227,7 +227,7 @@ def grid_plots(fname, plottingyaml):
                                 sharex=True, sharey=True)
         axs = axs.flat
         for n, k in enumerate(keys):
-            _log.debug('key', k)
+            _log.debug(f'key {k}')
 
             pconf = config['pcolor']['vars'][k]
             _log.debug(pconf)

--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -610,15 +610,15 @@ def datameta_to_nc(data, meta, outdir=None, name=None, check_exists=False,
 
     # trim data that has time==0
     ind = np.where(ds.time > 1e4)[0]
-    _log.debug(ds, ds.time, len(ind))
+    _log.debug(f'{ds}, {ds.time}, {len(ind)}')
     ds = ds.isel(_ind=ind)
     ds['_ind'] = np.arange(len(ds.time)) + deployment_ind
     if len(ds['_ind'].values) > 1:
         deployment_ind = ds['_ind'].values[-1]
 
-    _log.info('Writing!', deployment_ind)
+    _log.info(f'Writing! {deployment_ind}')
     ds.to_netcdf(outname, format='NETCDF4')
-    _log.info('Wrote: %s', outname)
+    _log.info(f'Wrote:, {outname}')
     return ds, deployment_ind
 
 def merge_rawnc(indir, outdir, deploymentyaml, incremental=False,
@@ -810,12 +810,12 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
         if 1:
             ebdn = indir + '/' + id + f'-{mnum:04d}-rawebd.nc'
             dbdn = indir + '/' + id + f'-{mnum:04d}-rawdbd.nc'
-            _log.debug(ebdn, dbdn)
+            _log.debug(f'{ebdn}, {dbdn}')
             if os.path.exists(ebdn) and os.path.exists(dbdn):
                 _log.info('Opening:', ebdn, dbdn)
                 ebd = xr.open_dataset(ebdn, decode_times=False)
                 dbd = xr.open_dataset(dbdn, decode_times=False)
-                _log.debug('DBD', dbd, dbd.m_depth)
+                _log.debug(f'DBD, {dbd}, {dbd.m_depth}')
                 if len(ebd.time) > 2:
                     # build a new data set based on info in `deployment.`
                     # We will use ebd.m_present_time as the interpolant if the
@@ -856,8 +856,8 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
                             attrs = utils.fill_required_attrs(attrs)
                             ds[name] = (('time'), val.data, attrs)
 
-                    _log.debug('HERE', ds)
-                    _log.debug('HERE', ds.pressure[0:100])
+                    _log.debug(f'HERE, {ds}')
+                    _log.debug(f'HERE, {ds.pressure[0:100]}')
                     # some derived variables:
                     # trim bad times...
                     #ds = ds.sel(time=slice(1e8, None))
@@ -942,7 +942,7 @@ def _dbd2ebd(dbd, ds, val):
     vout = ds.time * 0.0
     goodt = np.where(np.isfinite(ds.time))[0]
     if (len(goodt) > 1) and (len(good) > 1):
-        _log.debug('GOOOD', goodt, good)
+        _log.debug(f'GOOD, {goodt}, {good}')
         vout[goodt] = np.interp(ds.time[goodt].values,
             dbd.m_present_time.values[good], val[good].values)
     return vout

--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -610,13 +610,13 @@ def datameta_to_nc(data, meta, outdir=None, name=None, check_exists=False,
 
     # trim data that has time==0
     ind = np.where(ds.time > 1e4)[0]
-    print(ds, ds.time, len(ind))
+    _log.debug(ds, ds.time, len(ind))
     ds = ds.isel(_ind=ind)
     ds['_ind'] = np.arange(len(ds.time)) + deployment_ind
     if len(ds['_ind'].values) > 1:
         deployment_ind = ds['_ind'].values[-1]
 
-    print('Writing!', deployment_ind)
+    _log.info('Writing!', deployment_ind)
     ds.to_netcdf(outname, format='NETCDF4')
     _log.info('Wrote: %s', outname)
     return ds, deployment_ind
@@ -717,7 +717,7 @@ def merge_rawncBrutal(indir, outdir, deploymentyaml, incremental=False,
     _log.info('Opening *.ebd.nc multi-file dataset')
     scifiles = sorted(glob.glob(indir + '/*.' + scisuffix + '.nc'))
     for fn in scifiles:
-        print(fn)
+        _log.debug(fn)
     glifiles = sorted(glob.glob(indir + '/*.' + glidersuffix + '.nc'))
 
     if len(scifiles) > 1:
@@ -728,7 +728,7 @@ def merge_rawncBrutal(indir, outdir, deploymentyaml, incremental=False,
         ds = None
         num = 0
         for nn, name in enumerate(scifiles):
-            print('Hello')
+            _log.debug('Hello')
             _log.info(f'merging {scifiles[nn]}')
             with xr.open_dataset(name, decode_times=True) as ds2:
                 if 1:
@@ -810,12 +810,12 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
         if 1:
             ebdn = indir + '/' + id + f'-{mnum:04d}-rawebd.nc'
             dbdn = indir + '/' + id + f'-{mnum:04d}-rawdbd.nc'
-            print(ebdn, dbdn)
+            _log.debug(ebdn, dbdn)
             if os.path.exists(ebdn) and os.path.exists(dbdn):
-                print('Opening:', ebdn, dbdn)
+                _log.info('Opening:', ebdn, dbdn)
                 ebd = xr.open_dataset(ebdn, decode_times=False)
                 dbd = xr.open_dataset(dbdn, decode_times=False)
-                print('DBD', dbd, dbd.m_depth)
+                _log.debug('DBD', dbd, dbd.m_depth)
                 if len(ebd.time) > 2:
                     # build a new data set based on info in `deployment.`
                     # We will use ebd.m_present_time as the interpolant if the
@@ -856,8 +856,8 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
                             attrs = utils.fill_required_attrs(attrs)
                             ds[name] = (('time'), val.data, attrs)
 
-                    print('HERE', ds)
-                    print('HERE', ds.pressure[0:100])
+                    _log.debug('HERE', ds)
+                    _log.debug('HERE', ds.pressure[0:100])
                     # some derived variables:
                     # trim bad times...
                     #ds = ds.sel(time=slice(1e8, None))
@@ -891,7 +891,7 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
 
     # now merge:
     with xr.open_mfdataset(outdir + '/' + id + '*-M*_L0.nc', decode_times=False, lock=False) as ds:
-        print(ds.attrs)
+        _log.debug(ds.attrs)
 
         # put the real start and end times:
         start = ((ds['time'].values[0]).astype('timedelta64[s]') +
@@ -901,15 +901,15 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
 
         ds.attrs['deployment_start'] = str(start)
         ds.attrs['deployment_end'] = str(end)
-        print(ds.depth.values[:100])
-        print(ds.depth.values[2000:2100])
+        _log.debug(ds.depth.values[:100])
+        _log.debug(ds.depth.values[2000:2100])
         ds = utils.get_profiles_new(ds,
                 filt_time=profile_filt_time, profile_min_time=profile_min_time)
-        print(ds.depth.values[:100])
-        print(ds.depth.values[2000:2100])
+        _log.debug(ds.depth.values[:100])
+        _log.debug(ds.depth.values[2000:2100])
 
         outname = outdir + '/' + id0 + '.nc'
-        print(outname)
+        _log.info(outname)
         ds.to_netcdf(outname)
     return outname
 
@@ -942,7 +942,7 @@ def _dbd2ebd(dbd, ds, val):
     vout = ds.time * 0.0
     goodt = np.where(np.isfinite(ds.time))[0]
     if (len(goodt) > 1) and (len(good) > 1):
-        print('GOOOD', goodt, good)
+        _log.debug('GOOOD', goodt, good)
         vout[goodt] = np.interp(ds.time[goodt].values,
             dbd.m_present_time.values[good], val[good].values)
     return vout

--- a/pyglider/utils.py
+++ b/pyglider/utils.py
@@ -111,7 +111,7 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
 
     good = np.where(np.isfinite(ds.pressure))[0]
     dt = float(np.median(np.diff(ds.time.values[good[:200000]])))
-    _log.info('dt', dt)
+    _log.info(f'dt, {dt}')
     filt_length = int(filt_time /  dt)
 
     min_nsamples = int(profile_min_time / dt)
@@ -119,7 +119,7 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
 
     p = np.convolve(ds.pressure.values[good],
                     np.ones(filt_length) / filt_length, 'same')
-    _log.info('filt', filt_length)
+    _log.info('ffilt, {filt_length}')
     decim = int(filt_length / 3)
     if decim < 2:
         decim = 2
@@ -135,7 +135,7 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
     if mins[-1] < maxs[-1]:
         mins = np.concatenate((mins, good[[-1]]))
 
-    _log.info(f'mins: {len(mins)} {mins} , maxs: {len(maxs)} {maxs}')
+    _log.debug(f'mins: {len(mins)} {mins} , maxs: {len(maxs)} {maxs}')
 
     pronum = 0
     p = ds.pressure
@@ -150,8 +150,8 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
                 break
             _log.debug(nmax)
             ins = range(int(mins[nmin]), int(maxs[nmax]+1))
-            _log.debug(pronum, ins, len(p), mins[nmin], maxs[nmax])
-            _log.debug('Down', ins, p[ins[0]].values,p[ins[-1]].values)
+            _log.debug(f'{pronum}, {ins}, {len(p)}, {mins[nmin]}, {maxs[nmax]}')
+            _log.debug(f'Down, {ins}, {p[ins[0]].values},{p[ins[-1]].values}')
             if (len(ins) > min_nsamples and np.nanmax(p[ins]) - np.nanmin(p[ins]) > min_dp):
                 profile[ins] = pronum
                 direction[ins] = +1
@@ -162,8 +162,8 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
             else:
                 break
             ins = range(maxs[nmax], mins[nmin])
-            _log.debug(pronum, ins, len(p), mins[nmin], maxs[nmax])
-            _log.debug('Up', ins, p[ins[0]].values, p[ins[-1]].values)
+            _log.debug(f'{pronum}, {ins}, {len(p)}, {mins[nmin]}, {maxs[nmax]}')
+            _log.debug(f'Up, {ins}, {p[ins[0]].values}, {p[ins[-1]].values}')
             if (len(ins) > min_nsamples and np.nanmax(p[ins]) - np.nanmin(p[ins]) > min_dp):
                 # up
                 profile[ins] = pronum
@@ -309,7 +309,7 @@ def get_file_id(ds):
         dt = time_to_datetime64(ds.time.values[0])
     else:
         dt = ds.time.values[0].astype('datetime64[s]')
-    _log.debug('dt', dt)
+    _log.debug(f'dt, {dt}')
     id = (ds.attrs['glider_name'] + ds.attrs['glider_serial'] + '-' +
                       dt.item().strftime('%Y%m%dT%H%M'))
     return id

--- a/pyglider/utils.py
+++ b/pyglider/utils.py
@@ -64,7 +64,7 @@ def get_profiles(ds, min_dp = 10.0, inversion=3., filt_length=7,
         inds = np.arange(good[inflect[n]], good[inflect[n+1]]+1) + 1
         dp = np.diff(ds.pressure[inds[[-1, 0]]])
         if ((nprofile >= min_nsamples) and (np.abs(dp) > 10)):
-            print('Good')
+            _log.debug('Good')
             direction[inds] = np.sign(dp)
             profile[inds] = pronum
             lastpronum = pronum
@@ -111,7 +111,7 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
 
     good = np.where(np.isfinite(ds.pressure))[0]
     dt = float(np.median(np.diff(ds.time.values[good[:200000]])))
-    print('dt', dt)
+    _log.info('dt', dt)
     filt_length = int(filt_time /  dt)
 
     min_nsamples = int(profile_min_time / dt)
@@ -119,7 +119,7 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
 
     p = np.convolve(ds.pressure.values[good],
                     np.ones(filt_length) / filt_length, 'same')
-    print('filt', filt_length)
+    _log.info('filt', filt_length)
     decim = int(filt_length / 3)
     if decim < 2:
         decim = 2
@@ -148,10 +148,10 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
                 nmax = nmax[0]
             else:
                 break
-            print(nmax)
+            _log.debug(nmax)
             ins = range(int(mins[nmin]), int(maxs[nmax]+1))
-            print(pronum, ins, len(p), mins[nmin], maxs[nmax])
-            print('Down', ins, p[ins[0]].values,p[ins[-1]].values)
+            _log.debug(pronum, ins, len(p), mins[nmin], maxs[nmax])
+            _log.debug('Down', ins, p[ins[0]].values,p[ins[-1]].values)
             if (len(ins) > min_nsamples and np.nanmax(p[ins]) - np.nanmin(p[ins]) > min_dp):
                 profile[ins] = pronum
                 direction[ins] = +1
@@ -162,17 +162,17 @@ def get_profiles_new(ds, min_dp = 10.0, inversion=3., filt_time=100,
             else:
                 break
             ins = range(maxs[nmax], mins[nmin])
-            print(pronum, ins, len(p), mins[nmin], maxs[nmax])
-            print('Up', ins, p[ins[0]].values, p[ins[-1]].values)
+            _log.debug(pronum, ins, len(p), mins[nmin], maxs[nmax])
+            _log.debug('Up', ins, p[ins[0]].values, p[ins[-1]].values)
             if (len(ins) > min_nsamples and np.nanmax(p[ins]) - np.nanmin(p[ins]) > min_dp):
                 # up
                 profile[ins] = pronum
                 direction[ins] = -1
                 pronum += 1
         else:
-            print('Failed?')
+            _log.debug('Failed?')
 
-    print('Doing this...')
+    _log.debug('Doing this...')
     attrs = collections.OrderedDict([('long_name', 'profile index'),
              ('units', '1'),
              ('comment',
@@ -304,12 +304,12 @@ def fill_required_attrs(attrs):
 
 def get_file_id(ds):
 
-    print(ds.time)
+    _log.debug(ds.time)
     if not ds.time.dtype=='datetime64[ns]':
         dt = time_to_datetime64(ds.time.values[0])
     else:
         dt = ds.time.values[0].astype('datetime64[s]')
-    print('dt', dt)
+    _log.debug('dt', dt)
     id = (ds.attrs['glider_name'] + ds.attrs['glider_serial'] + '-' +
                       dt.item().strftime('%Y%m%dT%H%M'))
     return id
@@ -447,7 +447,7 @@ def parse_gliderxml_surfacedatetime(fname):
         y=BeautifulSoup(fin, features="xml")
         time = None
         for a in y.find_all('report'):
-            print(a)
+            _log.debug(a)
             if a.text is not None:
                 try:
                     time = np.append(time, np.datetime64(a.text))

--- a/pyglider/website.py
+++ b/pyglider/website.py
@@ -111,7 +111,7 @@ def geojson_deployments(dir, outfile='cproof-deployments.geojson'):
     kml = simplekml.Kml()
 
     np.random.seed(20190101)
-    _log.debug('subdirs', subdirs)
+    _log.debug(f'subdirs, {subdirs}')
     colornum = 0;
     for d in subdirs:
         _log.info(d)

--- a/pyglider/website.py
+++ b/pyglider/website.py
@@ -82,11 +82,11 @@ def index_deployments(dir, templatedir='./.templates/'):
                         continue
                 with xr.open_dataset(nc[0]) as ds:
                     att = ds.attrs
-                    print(type(ds.keys()))
+                    _log.debug(type(ds.keys()))
                     keys = []
                     units = []
                     for key in ds.keys():
-                        print(ds[key].attrs)
+                        _log.debug(ds[key].attrs)
                         try:
                             unit = ds[key].attrs['units']
                         except KeyError:
@@ -111,7 +111,7 @@ def geojson_deployments(dir, outfile='cproof-deployments.geojson'):
     kml = simplekml.Kml()
 
     np.random.seed(20190101)
-    print('subdirs', subdirs)
+    _log.debug('subdirs', subdirs)
     colornum = 0;
     for d in subdirs:
         _log.info(d)


### PR DESCRIPTION
I'm automating processing of our seaexplorer data. The logging is very useful, but the print statements throw a lot of non-essential info into std out, which makes investigating errors a bit of a chore. 

As a suggestion, I have replaced all print statements with _log.info where they are useful, one line statements and _log.debug when they are larger, or appear designed more for troubleshooting than regular operation.

None of these suggestions are set in stone. What do you think?