### PR TITLE
match timestamps of oxygen and ctd before correcting

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,4 +31,4 @@ def test_oxygen_concentration_correction_variables_unchanged(var):
 def test_oxygen_concentration_correction():
     oxygen_difference = np.nanmean(ds_out['oxygen_concentration'].values) \
                         - np.nanmean(ds_unchanged['oxygen_concentration'].values)
-    assert np.abs(oxygen_difference + 32.373) < 1e-2
+    assert np.abs(oxygen_difference + 32.328) < 1e-2


### PR DESCRIPTION
This PR resolves #52 

Rather than only using temperature and salinity from exactly matching timestamps, it used xarray da.reindex to find the nearest ctd sample to use for the correction.

