### PR TITLE
Fixed error with time variable when writing netcdf file

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -361,6 +361,8 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, kind='raw',
     _log.info('writing %s', outname)
     if 'units' in ds.time.attrs.keys():
         ds.time.attrs.pop('units')
+    if 'calendar' in ds.time.attrs.keys():
+        ds.time.attrs.pop('calendar')
     if 'ad2cp_time' in list(ds):
         if 'units' in ds.ad2cp_time.attrs.keys():
             ds.ad2cp_time.attrs.pop('units')


### PR DESCRIPTION
There was a problem in seaexplorer.py because of how 
xarray handles the encoding for the calendar in attrs on 
variable 'time'. To fix it, I replicated the code used to fix 
the same issue with the encoding for the units in attrs on 
variable 'time'. There may be other places this fix is needed.