### PR TITLE
allow alternative averaging strategies for gridded product

### DIFF
--- a/example-seaexplorer-legato-flntu-arod-ad2cp/deploymentRealtime.yml
+++ b/example-seaexplorer-legato-flntu-arod-ad2cp/deploymentRealtime.yml
@@ -206,12 +206,16 @@ netcdf_variables:
     standard_name: concentration_of_chlorophyll_in_sea_water
     units:        mg m-3
     coordinates:  time depth latitude longitude
+    # example of how to use median rather than mean when producing gridded average netCDF
+    average_method: median
 
   cdom:
     source:  FLNTU_NTU_SCALED
     long_name:    flntu variable
     units:        arbitrary
     coordinates:  time depth latitude longitude
+    # Use geometric mean for gridded netCDF. Useful for PAR
+    average_method: "geometric mean"
 
 
 

--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -180,10 +180,10 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
             if len(good) > 0:
                 if "average_method" in ds[k].attrs:
                     average_method = ds[k].attrs["average_method"]
-                    _log.warning(f"Using average method {average_method} for variable {k} following deployment yaml")
+                    ds[k].attrs["processing"] = f"Using average method {average_method} for variable {k} following deployment yaml."
                     if average_method == "geometric mean":
                         average_method = stats.gmean
-                        _log.warning("Using geometric mean implementation scipy.stats.gmean")
+                        ds[k].attrs["processing"] += " Using geometric mean implementation scipy.stats.gmean"
                 else:
                     average_method = "mean"
                 dat, xedges, yedges, binnumber = stats.binned_statistic_2d(

--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -176,13 +176,20 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
     for k in ds.keys():
         if k not in ['time', 'longitude', 'latitude', 'depth'] and 'time' not in k:
             _log.info('Gridding %s', k)
-
             good = np.where(~np.isnan(ds[k]) & (ds['profile_index'] % 1 == 0))[0]
             if len(good) > 0:
+                if "average_method" in ds[k].attrs:
+                    average_method = ds[k].attrs["average_method"]
+                    _log.warning(f"Using average method {average_method} for variable {k} following deployment yaml")
+                    if average_method == "geometric mean":
+                        average_method = stats.gmean
+                        _log.warning("Using geometric mean implementation scipy.stats.gmean")
+                else:
+                    average_method = "mean"
                 dat, xedges, yedges, binnumber = stats.binned_statistic_2d(
                         ds['profile_index'].values[good],
                         ds['depth'].values[good],
-                        values=ds[k].values[good], statistic='mean',
+                        values=ds[k].values[good], statistic=average_method,
                         bins=[profile_bins, depth_bins])
 
             _log.debug(f'dat{np.shape(dat)}')


### PR DESCRIPTION
Allow the user to specify averaging scheme used by scipy.stats.binned_statistic_2d when creating the gridded netCDF. Defaults to using mean as is currently set.

This resolved #58 