### PR TITLE
MNT: rename L0 methods

### DIFF
--- a/example-seaexplorer-legato-flntu-arod-ad2cp/process_deploymentRealTime.py
+++ b/example-seaexplorer-legato-flntu-arod-ad2cp/process_deploymentRealTime.py
@@ -24,9 +24,9 @@ if __name__ == '__main__':
     # merge individual netcdf files into single netcdf files *.gli*.nc and *.pld1*.nc
     seaexplorer.merge_rawnc(rawncdir, rawncdir, deploymentyaml, kind='sub')
     # Make level-0 timeseries netcdf file from the raw files...
-    outname = seaexplorer.raw_to_L0timeseries(rawncdir, l0tsdir, deploymentyaml, kind='sub')
-    ncprocess.extract_L0timeseries_profiles(outname, profiledir, deploymentyaml)
-    outname2 = ncprocess.make_L0_gridfiles(outname, griddir, deploymentyaml)
+    outname = seaexplorer.raw_to_timeseries(rawncdir, l0tsdir, deploymentyaml, kind='sub')
+    ncprocess.extract_timeseries_profiles(outname, profiledir, deploymentyaml)
+    outname2 = ncprocess.make_gridfiles(outname, griddir, deploymentyaml)
     # make profile netcdf files for ioos gdac...
     # make grid of dataset....
     pgplot.timeseries_plots(outname, plottingyaml)

--- a/example-seaexplorer/process_deploymentRealTime.py
+++ b/example-seaexplorer/process_deploymentRealTime.py
@@ -32,9 +32,9 @@ if 1:
     seaexplorer.merge_rawnc(rawncdir, rawncdir, deploymentyaml, kind='sub')
 
         # Make level-1 timeseries netcdf file from th raw files...
-    outname = seaexplorer.raw_to_L0timeseries(rawncdir, l0tsdir, deploymentyaml, kind='sub')
-    ncprocess.extract_L0timeseries_profiles(outname, profiledir, deploymentyaml)
-    outname2 = ncprocess.make_L0_gridfiles(outname, griddir, deploymentyaml)
+    outname = seaexplorer.raw_to_timeseries(rawncdir, l0tsdir, deploymentyaml, kind='sub')
+    ncprocess.extract_timeseries_profiles(outname, profiledir, deploymentyaml)
+    outname2 = ncprocess.make_gridfiles(outname, griddir, deploymentyaml)
 
 if 1:
     # make profile netcdf files for ioos gdac...

--- a/example-slocum/process_deploymentRealTime.py
+++ b/example-slocum/process_deploymentRealTime.py
@@ -39,15 +39,12 @@ if 1:
         scisuffix=scisuffix, glidersuffix=glidersuffix)
 if 1:
     # Make level-1 timeseries netcdf file from th raw files...
-    outname = slocum.raw_to_L0timeseries(rawdir, l1tsdir, deploymentyaml,
+    outname = slocum.raw_to_timeseries(rawdir, l1tsdir, deploymentyaml,
               profile_filt_time=100, profile_min_time=300)
     # make profile netcdf files for ioos gdac...
-    ncprocess.extract_L0timeseries_profiles(outname, profiledir, deploymentyaml)
+    ncprocess.extract_timeseries_profiles(outname, profiledir, deploymentyaml)
 
     # make grid of dataset....
 
-#pgplot.timeseries_plots(outname, plottingyaml)
-
-
-outname = ncprocess.make_L0_gridfiles(outname, griddir, deploymentyaml)
+outname = ncprocess.make_gridfiles(outname, griddir, deploymentyaml)
 pgplot.grid_plots(outname, plottingyaml)

--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -11,7 +11,7 @@ import scipy.stats as stats
 
 _log = logging.getLogger(__name__)
 
-def extract_L0timeseries_profiles(inname, outdir, deploymentyaml):
+def extract_timeseries_profiles(inname, outdir, deploymentyaml):
     """
     """
     try:
@@ -104,7 +104,7 @@ def extract_L0timeseries_profiles(inname, outdir, deploymentyaml):
                     nc.renameDimension('string%d' % trajlen, 'traj_strlen')
 
 
-def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
+def make_gridfiles(inname, outdir, deploymentyaml, dz=1):
     """
     """
     try:
@@ -216,3 +216,8 @@ def make_L0_gridfiles(inname, outdir, deploymentyaml, dz=1):
     _log.info('Done gridding')
 
     return outname
+
+
+# aliases
+make_L0_gridfiles = make_gridfiles
+extract_L0timeseries_profiles = extract_timeseries_profiles

--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -247,7 +247,7 @@ def _interp_pld_to_pld(pld, ds, val, indctd):
     return val
 
 
-def raw_to_L0timeseries(indir, outdir, deploymentyaml, kind='raw',
+def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
                         profile_filt_time=100, profile_min_time=300):
     """
     A little different than above, for the 4-file version of the data set.
@@ -392,7 +392,7 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, kind='raw',
     return outname
 
 # alias:
-raw_to_L1timeseries = raw_to_L0timeseries
+raw_to_L1timeseries = raw_to_L0timeseries = raw_to_timeseries
 
 
 def _parse_sensor_config(filename):

--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -772,7 +772,7 @@ def merge_rawncBrutal(indir, outdir, deploymentyaml, incremental=False,
     return
 
 
-def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
+def raw_to_timeseries(indir, outdir, deploymentyaml, *,
                         profile_filt_time=100, profile_min_time=300):
     """
     Parameters
@@ -912,8 +912,10 @@ def raw_to_L0timeseries(indir, outdir, deploymentyaml, *,
         ds.to_netcdf(outname)
     return outname
 
+
 # alias:
-raw_to_L1timeseries = raw_to_L0timeseries
+raw_to_L1timeseries = raw_to_L0timeseries = raw_to_timeseries
+
 
 def timeseries_get_profiles(inname, profile_filt_time=100,
                             profile_min_time=400):

--- a/tests/test_pyglider.py
+++ b/tests/test_pyglider.py
@@ -59,7 +59,7 @@ slocum.binary_to_rawnc(binarydir, rawdir_slocum, cacdir, sensorlist, deploymenty
 
 slocum.merge_rawnc(rawdir_slocum, rawdir_slocum, deploymentyaml_slocum,
                    scisuffix=scisuffix, glidersuffix=glidersuffix)
-outname_slocum = slocum.raw_to_L0timeseries(rawdir_slocum, l1tsdir, deploymentyaml_slocum,
+outname_slocum = slocum.raw_to_timeseries(rawdir_slocum, l1tsdir, deploymentyaml_slocum,
                                             profile_filt_time=100, profile_min_time=300)
 output_slocum = xr.open_dataset(outname_slocum)
 # Open test data file

--- a/tests/test_seaexplorer.py
+++ b/tests/test_seaexplorer.py
@@ -14,8 +14,8 @@ def test__outputname():
                             'tests/data/realtime_rawnc/')
     assert fnout == 'tests/data/realtime_rawnc/sea035.0012.pld1.sub.0036.nc'
     assert filenum == 36
-   
-   
+
+
 
 
 def test_raw_to_rawnc():
@@ -76,18 +76,17 @@ def test__interp_gli_to_pld():
     assert len(pitch_interp) == len(ds.time)
 
 
-def test_raw_to_L0timeseries():
+def test_raw_to_timeseries():
     # Test default, will fail as we have sub data, not raw data
     with pytest.raises(FileNotFoundError) as missing_file_exc:
-        result_default = seaexplorer.raw_to_L0timeseries('tests/data/realtime_rawnc/',
+        result_default = seaexplorer.raw_to_timeseries('tests/data/realtime_rawnc/',
                                                         'tests/data/l0-profiles/',
                                                         'example-seaexplorer/deploymentRealtime.yml',
                                                         )
-    result_sub = seaexplorer.raw_to_L0timeseries('tests/data/realtime_rawnc/',
+    result_sub = seaexplorer.raw_to_timeseries('tests/data/realtime_rawnc/',
                                                     'tests/data/l0-profiles/',
                                                     'example-seaexplorer/deploymentRealtime.yml',
                                                     kind='sub')
     assert 'No such file or directory' in str(missing_file_exc)
     assert result_sub == 'tests/data/l0-profiles/dfo-eva035-20190718.nc'
-    
-    
+


### PR DESCRIPTION
This renames all the `L0` methods to remove the level designation.  Thsee routines are not restricted to a processing level, and should not reflect that.  For back compatibility there are aliases to the old names.  