### PR TITLE
deduplicate timestamps with check

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -361,19 +361,22 @@ def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
     ds = utils.get_derived_eos_raw(ds)
 
     # somehow this comes out unsorted:
-    len_before_drop = len(ds.time)
     ds = ds.sortby(ds.time)
     # Drop duplicate timestamps and check how many are removed this way
-    ds = ds.drop_duplicates(dim="time")
-    len_after_drop = len(ds.time)
-    proportion_kept = len_after_drop / len_before_drop
-    loss_str = f"{100 * (1-proportion_kept)} % samples removed by timestamp deduplication."
-    if proportion_kept < 0.5:
-        raise ValueError(f"{loss_str} Check input data for duplicate timestamps")
-    elif proportion_kept < 0.999:
-        _log.warning(loss_str)
+    if "drop_duplicates" in ds.__dir__():
+        len_before_drop = len(ds.time)
+        ds = ds.drop_duplicates(dim="time")
+        len_after_drop = len(ds.time)
+        proportion_kept = len_after_drop / len_before_drop
+        loss_str = f"{100 * (1-proportion_kept)} % samples removed by timestamp deduplication."
+        if proportion_kept < 0.5:
+            raise ValueError(f"{loss_str} Check input data for duplicate timestamps")
+        elif proportion_kept < 0.999:
+            _log.warning(loss_str)
+        else:
+            _log.info(loss_str)
     else:
-        _log.info(loss_str)
+        _log.warning("drop_duplicates not found in xarray. Install xarray>=2022.3.0 for deduplication functionality")
 
     # Correct oxygen if present:
     if 'oxygen_concentration' in ncvar.keys():

--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -360,6 +360,21 @@ def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
                                 profile_min_time=profile_min_time)
     ds = utils.get_derived_eos_raw(ds)
 
+    # somehow this comes out unsorted:
+    len_before_drop = len(ds.time)
+    ds = ds.sortby(ds.time)
+    # Drop duplicate timestamps and check how many are removed this way
+    ds = ds.drop_duplicates(dim="time")
+    len_after_drop = len(ds.time)
+    proportion_kept = len_after_drop / len_before_drop
+    loss_str = f"{100 * (1-proportion_kept)} % samples removed by timestamp deduplication."
+    if proportion_kept < 0.5:
+        raise ValueError(f"{loss_str} Check input data for duplicate timestamps")
+    elif proportion_kept < 0.999:
+        _log.warning(loss_str)
+    else:
+        _log.info(loss_str)
+
     # Correct oxygen if present:
     if 'oxygen_concentration' in ncvar.keys():
         if 'correct_oxygen' in ncvar['oxygen_concentration'].keys():
@@ -373,9 +388,6 @@ def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
     # ds = ds._get_distance_over_ground(ds)
 
     ds = utils.fill_metadata(ds, deployment['metadata'], device_data)
-
-    # somehow this comes out unsorted:
-    ds = ds.sortby(ds.time)
 
     start = ds['time'].values[0]
     end = ds['time'].values[-1]


### PR DESCRIPTION
This resolves #95 

Varying response depending on how many samples are removed by this deduplication:
more than half lost - error
more than 0.1 % lost - warning
otherwise log

order by time and drop_duplicates moved before `oxygen_concentration_correction` so the reindex in this function does not breeak.