### PR TITLE
Ensures dbdreader 0.4.11 or better is used, avoiding rare but possible segmentation faults introduced in 0.4.9, and persisting in 0.4.10.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-bitstring
-dbdreader
-dask
-gsw
-netcdf4
-numpy
-pooch
-scipy
-xarray
+.

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,15 @@ setup(name="pyglider",
       packages=find_packages(exclude=['tests']),
       python_requires='>=3.6',
       install_requires=[
+        "numpy", 
         "xarray",
         "dask",
         "netcdf4",
         "gsw",
         "scipy",
         "bitstring",
-        "pooch"
+        "pooch",
+        "dbdreader>=0.4.11"
       ],
       license='Apache',
       extras_require={


### PR DESCRIPTION
Hi,

I recently discovered and fixed a bug in dbdreader, which caused in some rare cases a memory corruption resulting in python to quit with a segmentation fault. This problem was introduced in version 0.4.9. Enhancements to the benefit of pyglider were introduced in 0.4.10. So to ensure pyglider has the enhancements in dbdreader it needs, and to avoid any segmentation errors, it is best to require dbdreader version 0.4.11 at least.

I modified the setup.py to reflect this, and noticed that dbdreader was not present in setup.py but it was in requirements.txt. This is also the case for numpy. I assume what is wanted that both modules are present in the setup.py, and that requirements.txt should have identical information. To avoid entering the same information twice, this could achieved by having requirements.txt to contain a single ".". Then pip install ... works as well as pip install -r requirements.txt.