### PR TITLE
fix conda install commands

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -7,9 +7,9 @@ hence we recommend these be installed with [``conda``](https://www.anaconda.com/
 PyGlider, create an environment, and do
 
 ```
-conda env create -n gliderwork
+conda create -n gliderwork
 conda activate gliderwork
-conda install pyglider
+conda install -c conda-forge pyglider
 ```
 
 ## Editable installation


### PR DESCRIPTION
Following conda (bottom of [this page](https://docs.conda.io/projects/conda/en/stable/commands/create.html)) one should use `conda create` not `conda env create` to make a new named env. I've also specified `-c conda-forge` so it looks at the correct repo to find pyglider.