### PR TITLE
Add attributes to the time variable in netcdf files

### DIFF
--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -845,7 +845,7 @@ def binary_to_timeseries(indir, cachedir, outdir, deploymentyaml, *,
     attr = {}
     name = 'time'
     for atts in ncvar[name].keys():
-        if atts != 'coordinates':
+        if (atts != 'coordinates') & (atts != 'units') & (atts != 'calendar'):
             attr[atts] = ncvar[name][atts]
     if 'sci_m_present_time' in dbd.parameterNames['sci']:
         time_base = 'sci_m_present_time'
@@ -902,8 +902,8 @@ def binary_to_timeseries(indir, cachedir, outdir, deploymentyaml, *,
     ds = ds.assign_coords(latitude=ds.latitude)
     ds = ds.assign_coords(depth=ds.depth)
 
-    ds['time'] = (ds.time.values.astype('timedelta64[s]') +
-                  np.datetime64('1970-01-01T00:00:00'))
+    ds['time'] = (('time'), ds.time.values.astype('timedelta64[s]') +
+                  np.datetime64('1970-01-01T00:00:00'), attr)
     ds = utils.fill_metadata(ds, deployment['metadata'], device_data)
     start = ds['time'].values[0]
     end = ds['time'].values[-1]


### PR DESCRIPTION
Changed two lines in slocum.py to make sure that the attributes for the time variable are not getting lost or being specified twice. Attributes are from the metadata yaml file.