### PR TITLE
Fix time variable attributes for IOOS metadata

### DIFF
--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -114,7 +114,10 @@ def extract_timeseries_profiles(inname, outdir, deploymentyaml):
                 if 'units' in dss.profile_time.attrs:
                     dss.profile_time.attrs.pop('units')
                 timeunits = 'seconds since 1970-01-01T00:00:00Z'
-                dss.to_netcdf(outname, encoding={'time': {'units': timeunits}})
+                timecalendar = 'gregorian'
+                dss.to_netcdf(outname, encoding={'time': {'units': timeunits, 
+                                                          'calendar': timecalendar,
+                                                          '_FillValue': None}})
 
                 # add traj_strlen using bare ntcdf to make IOOS happy
                 with netCDF4.Dataset(outname, 'r+') as nc:

--- a/pyglider/utils.py
+++ b/pyglider/utils.py
@@ -67,8 +67,10 @@ def get_glider_depth(ds):
     attr = {'source': 'pressure', 'long_name': 'glider depth',
             'standard_name': 'depth', 'units': 'm',
             'comment': 'from science pressure and interpolated',
+            'instrument': 'instrument_ctd',
             'observation_type': 'calulated',
             'accuracy': '1', 'precision': '2', 'resolution': '0.02',
+            'platform': 'platform',
             'valid_min': '0', 'valid_max': '2000',
             'reference_datum': 'surface', 'positive': 'down'}
     ds['depth'].attrs = attr


### PR DESCRIPTION
Modified the attributes for the time variable in ncprocess.py to be compliant with IOOS requirements, including the calendar, units, and FillValue used. 