### PR TITLE
Fixed time_profile variable units to be IOOS compliant.

### DIFF
--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -111,12 +111,12 @@ def extract_timeseries_profiles(inname, outdir, deploymentyaml):
 
                 # outname = outdir + '/' + utils.get_file_id(dss) + '.nc'
                 _log.info('Writing %s', outname)
-                if 'units' in dss.profile_time.attrs:
-                    dss.profile_time.attrs.pop('units')
                 timeunits = 'seconds since 1970-01-01T00:00:00Z'
                 timecalendar = 'gregorian'
                 dss.to_netcdf(outname, encoding={'time': {'units': timeunits,
-                                                          'calendar': timecalendar}})
+                                                          'calendar': timecalendar},
+                                                          'profile_time': 
+                                                         {'units': timeunits}})
 
                 # add traj_strlen using bare ntcdf to make IOOS happy
                 with netCDF4.Dataset(outname, 'r+') as nc:


### PR DESCRIPTION
The variable time_profile had units that were e.g., 'seconds from 2022-12-01' but with the time changing for each profile. Code has been modified so the
correct units will show up for all profiles. This
fix also solved an issue where the value of time_profile was showing up as zero for some reason.