### PR TITLE
Fix for SeaExplorer code to avoid interpolating over large gaps

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -388,9 +388,9 @@ def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
                     else:
                         val = np.interp(time_timebase.astype(float), time_var.astype(float), var_non_nan)
 
-                        # interpolate only over those gaps that are smaller than 'maxgap'                        
-                        tg_ind = utils.find_gaps(time_var.astype(float),time_timebase.astype(float),maxgap)
-                        val[tg_ind] = np.nan
+                    # interpolate only over those gaps that are smaller than 'maxgap'                        
+                    tg_ind = utils.find_gaps(time_var.astype(float),time_timebase.astype(float),maxgap)
+                    val[tg_ind] = np.nan
                 else:
                     val = val[indctd]
 

--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -302,7 +302,7 @@ def _remove_fill_values(df, fill_value=9999):
 
 
 def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
-                      profile_filt_time=100, profile_min_time=300, interpolate=False, fnamesuffix=''):
+                      profile_filt_time=100, profile_min_time=300, maxgap=300, interpolate=False, fnamesuffix=''):
     """
     A little different than above, for the 4-file version of the data set.
     """
@@ -387,6 +387,10 @@ def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
                         val = np.datetime64("1970-01-01") + val_us
                     else:
                         val = np.interp(time_timebase.astype(float), time_var.astype(float), var_non_nan)
+
+                        # interpolate only over those gaps that are smaller than 'maxgap'                        
+                        tg_ind = utils.find_gaps(time_var.astype(float),time_timebase.astype(float),maxgap)
+                        val[tg_ind] = np.nan
                 else:
                     val = val[indctd]
 


### PR DESCRIPTION
This fix uses the same `utils.findgaps` function as the Slocum code, and only interpolates over gaps that are larger than the user-specified parameter `maxgap`.