### PR TITLE
Added a FillValue for u, v to allow profile submission to IOOS

### DIFF
--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -67,7 +67,7 @@ def extract_timeseries_profiles(inname, outdir, deploymentyaml):
 
                     dss['v'] = dss.water_velocity_northward.mean()
                     dss['v'].attrs = profile_meta['v']
-                else:
+                elif ('water_velocity_eastward' not in dss.keys()) and ('_FillValue' in profile_meta['u']):
                     dss['u'] = profile_meta['u']['_FillValue']
                     dss['u'].attrs = profile_meta['u']
 

--- a/pyglider/ncprocess.py
+++ b/pyglider/ncprocess.py
@@ -67,6 +67,12 @@ def extract_timeseries_profiles(inname, outdir, deploymentyaml):
 
                     dss['v'] = dss.water_velocity_northward.mean()
                     dss['v'].attrs = profile_meta['v']
+                else:
+                    dss['u'] = profile_meta['u']['_FillValue']
+                    dss['u'].attrs = profile_meta['u']
+
+                    dss['v'] = profile_meta['v']['_FillValue']
+                    dss['v'].attrs = profile_meta['v']
 
                 dss['profile_id'] = np.array(p*1.0)
                 dss['profile_id'].attrs = profile_meta['profile_id']


### PR DESCRIPTION
As part of the `if` loop where the profile-averaged glider speed _u_ and _v_ are defined, I added an `else` statement to set _u_ and _v_ to a `FillValue` defined in the metadata yaml file, if ocean current speed isn't available (as is usually the case for realtime data).