### PR TITLE
fix dbdreader below 0.4.15

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,4 @@ dependencies:
   - pooch
   - polars
   - pip:
-    - dbdreader
+    - dbdreader<0.4.15

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -18,5 +18,4 @@ dependencies:
   - matplotlib
   - polars
   - pip:
-    - dbdreader
-
+    - dbdreader<0.4.15


### PR DESCRIPTION
The latest version of dbdreader (0.4.15 from May 25) breaks our code. This should fix Issue #155