### PR TITLE
Update for modified dbdreader api

### DIFF
--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -859,7 +859,7 @@ def binary_to_timeseries(indir, cachedir, outdir, deploymentyaml, *,
 
     # get the data, with `time_base` as the time source that
     # all other variables are synced to:
-    data = dbd.get_sync(*sensors)
+    data = list(dbd.get_sync(*sensors))
     # get the time:
     time = data.pop(0)
     ds['time'] = (('time'), time, attr)


### PR DESCRIPTION
The return values of the get* methods of dbdreader's classes DBD and MultiDBD have been made consistent across the methods by returning tuples of time and value vectors.  The existing code of the function binary_to_timeseries() got broken because of this, as it relies on the pop method of the return value, which tuples don't have. Converting the tuple into a list solves the issue.