### PR TITLE
pl.read_csv argument correction for different polars versions.

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -128,7 +128,7 @@ def raw_to_rawnc(indir, outdir, deploymentyaml, incremental=True,
                     # Try to read the file with polars. If the file is corrupted (rare), file read will fail and file
                     # is appended to badfiles
                     try:
-                        out = pl.read_csv(f, sep=';')
+                        out = pl.read_csv(f, separator=';')
                     except:
                         _log.warning(f'Could not read {f}')
                         badfiles.append(f)


### PR DESCRIPTION
Different polars versions do not necessarily recognise shorthand version of "separator" (ie. "sep") in read_csv function.