### PR TITLE
FIX: bad maxgap default

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -303,7 +303,8 @@ def _remove_fill_values(df, fill_value=9999):
 
 
 def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
-                      profile_filt_time=100, profile_min_time=300, maxgap=300, interpolate=False, fnamesuffix=''):
+                      profile_filt_time=100, profile_min_time=300,
+                      maxgap=10, interpolate=False, fnamesuffix=''):
     """
     A little different than above, for the 4-file version of the data set.
     """
@@ -390,7 +391,9 @@ def raw_to_timeseries(indir, outdir, deploymentyaml, kind='raw',
                         val = np.interp(time_timebase.astype(float), time_var.astype(float), var_non_nan)
 
                     # interpolate only over those gaps that are smaller than 'maxgap'
-                    tg_ind = utils.find_gaps(time_var.astype(float),time_timebase.astype(float),maxgap)
+                    # apparently maxgap is to be in somethng like seconds, and this data is in ms.  Certainly
+                    # the default of 0.3 s was not intended.  Changing default to 10 s:
+                    tg_ind = utils.find_gaps(time_var.astype(float), time_timebase.astype(float), maxgap*1000)
                     val[tg_ind] = np.nan
                 else:
                     val = val[indctd]

--- a/pyglider/utils.py
+++ b/pyglider/utils.py
@@ -574,6 +574,7 @@ def gappy_fill_vertical(data):
             data[:, j][ind[0]:ind[-1]] = np.interp(int, ind, data[ind, j])
     return data
 
+
 def find_gaps(sample_time, timebase, maxgap):
     """
     Return an index into *timebase* where True are times in gaps of *sample_time* larger
@@ -590,9 +591,10 @@ def find_gaps(sample_time, timebase, maxgap):
 
     # get the indices of timebase that are too large and account for the
     # degenerate case when a timebase point falls directly on a sample time.
-    index = ~np.logical_or((ddt <= maxgap),(np.isin(timebase,sample_time)))
+    index = ~np.logical_or((ddt <= maxgap), (np.isin(timebase,sample_time)))
 
     return index
+
 
 def _parse_gliderxml_pos(fname):
     """


### PR DESCRIPTION
maxgap was set to 300, but the units were milliseconds!  This lead to huge gaps in the data sets.  Changed so maxgap is in seconds, and default was changed to 10 s.   