### PR TITLE
Fix bug: set `have_dbdreader` to `False` if it's not installed

### DIFF
--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -12,7 +12,7 @@ try:
 
     have_dbdreader = True
 except ImportError:
-    have_dbdreader = True
+    have_dbdreader = False
 import glob
 import logging
 import os


### PR DESCRIPTION
Set `have_dbdreader` to `False` when it cannot be imported, so `binary_to_timeseries()` raises the proper `ImportError` instead of error out because the `dbdreader` variable is not defined.