### PR TITLE
sea explorer white space in payload files

### DIFF
--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -158,6 +158,12 @@ def raw_to_rawnc(
                             )
                         )
                         out = out.rename({'PLD_REALTIMECLOCK': 'time'})
+                    # remove leading and trailing whitespace
+                    # from entire dataframe
+                    for col_name in out.columns:
+                        out = out.with_columns(pl.col(col_name).str.strip_chars())
+                    # from column names
+                    out = out.rename(str.strip)
                     for col_name in out.columns:
                         if 'time' not in col_name.lower():
                             out = out.with_columns(pl.col(col_name).cast(pl.Float64))

--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -143,7 +143,6 @@ def raw_to_rawnc(
                         _log.warning(f'Could not read {f}')
                         badfiles.append(f)
                         continue
-
                     # Parse the datetime from nav files (called Timestamp) and pld1 files (called PLD_REALTIMECLOCK)
                     if 'Timestamp' in out.columns:
                         out = out.with_columns(

--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -159,9 +159,15 @@ def raw_to_rawnc(
                             )
                         )
                         out = out.rename({'PLD_REALTIMECLOCK': 'time'})
+                    # strip leading and trailing spaces
+                    out = out.with_columns(pl.col(pl.String).str.strip_chars())
+                    # replace empty values with None
+                    out = out.with_columns(pl.when(pl.col(pl.String).str.len_chars() == 0)
+                                           .then(None)
+                                           .otherwise(pl.col(pl.String))
+                                           .name.keep())
                     for col_name in out.columns:
                         if 'time' not in col_name.lower():
-                            out = out.with_columns(pl.col(col_name).str.strip_chars())
                             out = out.with_columns(pl.col(col_name).cast(pl.Float64))
                     # remove leading and trailing spaces from column names
                     out = out.rename(str.strip)

--- a/pyglider/seaexplorer.py
+++ b/pyglider/seaexplorer.py
@@ -143,6 +143,7 @@ def raw_to_rawnc(
                         _log.warning(f'Could not read {f}')
                         badfiles.append(f)
                         continue
+
                     # Parse the datetime from nav files (called Timestamp) and pld1 files (called PLD_REALTIMECLOCK)
                     if 'Timestamp' in out.columns:
                         out = out.with_columns(
@@ -158,15 +159,12 @@ def raw_to_rawnc(
                             )
                         )
                         out = out.rename({'PLD_REALTIMECLOCK': 'time'})
-                    # remove leading and trailing whitespace
-                    # from entire dataframe
-                    for col_name in out.columns:
-                        out = out.with_columns(pl.col(col_name).str.strip_chars())
-                    # from column names
-                    out = out.rename(str.strip)
                     for col_name in out.columns:
                         if 'time' not in col_name.lower():
+                            out = out.with_columns(pl.col(col_name).str.strip_chars())
                             out = out.with_columns(pl.col(col_name).cast(pl.Float64))
+                    # remove leading and trailing spaces from column names
+                    out = out.rename(str.strip)
                     # If AD2CP data present, convert timestamps to datetime
                     if 'AD2CP_TIME' in out.columns:
                         # Set datestamps with date 00000 to None


### PR DESCRIPTION
We have a number of missions from year 2018 with navigation firmware 2.1.5 and payload firmware 2.1.1. In the raw payload files there are leading whitespaces in both the data and the header which resulted in an error being thrown when converting the data to Float64. This fix resolves that issue.