### PR TITLE
small changes for metadata and debug calls

### DIFF
--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -971,11 +971,13 @@ def binary_to_timeseries(
         attrs = utils.fill_required_attrs(attrs)
         ds[name] = (('time'), val, attrs)
 
-    _log.info(f'Getting glider depths, {ds}')
-    _log.debug(f'HERE, {ds.pressure[0:100]}')
-
     if 'pressure' in ds:
+        _log.info(f'Getting glider depths')
+        _log.debug(ds)
+        _log.debug(f'HERE, {ds.pressure[0:100]}')
         ds = utils.get_glider_depth(ds)
+        _log.debug(ds.depth.values[:100])
+        _log.debug(ds.depth.values[2000:2100])
     try:
         ds = utils.get_distance_over_ground(ds)
     except:
@@ -992,22 +994,13 @@ def binary_to_timeseries(
 
     ds = utils.fill_metadata(ds, deployment['metadata'], device_data)
 
-    start = ds.time.values[0]
-    end = ds.time.values[-1]
     _log.debug('Long')
     _log.debug(ds.longitude.values[-2000:])
-    # make sure this is ISO readable....
-    ds.attrs['deployment_start'] = str(start)[:19]
-    ds.attrs['deployment_end'] = str(end)[:19]
-    _log.debug(ds.depth.values[:100])
-    _log.debug(ds.depth.values[2000:2100])
 
     if (profile_filt_time is not None) and (profile_min_time is not None):
         ds = utils.get_profiles_new(
             ds, filt_time=profile_filt_time, profile_min_time=profile_min_time
         )
-    _log.debug(ds.depth.values[:100])
-    _log.debug(ds.depth.values[2000:2100])
 
     try:
         os.mkdir(outdir)

--- a/pyglider/utils.py
+++ b/pyglider/utils.py
@@ -12,6 +12,8 @@ import xarray as xr
 import yaml
 from scipy.signal import argrelextrema
 
+from pyglider._version import __version__
+
 _log = logging.getLogger(__name__)
 
 
@@ -538,26 +540,31 @@ def fill_metadata(ds, metadata, sensor_data):
     ds.attrs['geospatial_lat_units'] = 'degrees_north'
     ds.attrs['geospatial_lon_units'] = 'degrees_east'
     ds.attrs['netcdf_version'] = '4.0'  # TODO get this somehow...
-    ds.attrs['history'] = 'CPROOF glider toolbox version: pre-tag'
+    ds.attrs['history'] = (
+        f'CPROOF glider toolbox pyglider version:  {__version__}'
+    )
     for k, v in metadata.items():
         ds.attrs[k] = v
     ds.attrs['featureType'] = 'trajectory'
     ds.attrs['cdm_data_type'] = 'Trajectory'
     ds.attrs['Conventions'] = 'CF-1.8'
-    ds.attrs['standard_name_vocabulary'] = 'CF STandard Name Table v72'
+    ds.attrs['standard_name_vocabulary'] = 'CF Standard Name Table v72'
     ds.attrs['date_created'] = str(np.datetime64('now')) + 'Z'
     ds.attrs['date_issued'] = str(np.datetime64('now')) + 'Z'
     ds.attrs['date_modified'] = ' '
     ds.attrs['id'] = get_file_id(ds)
-    ds.attrs['deployment_name'] = metadata['deployment_name']
     ds.attrs['title'] = ds.attrs['id']
 
     dt = ds.time.values
     ds.attrs['time_coverage_start'] = '%s' % dt[0]
     ds.attrs['time_coverage_end'] = '%s' % dt[-1]
+    
+    # make sure this is ISO readable....
+    ds.attrs['deployment_start'] = str(dt[0])[:19]
+    ds.attrs['deployment_end'] = str(dt[-1])[:19]
 
     ds.attrs['processing_level'] = (
-        'Level 0 (L0) processed data timeseries; ' 'no corrections or data screening'
+        'Level 0 (L0) processed data timeseries; no corrections or data screening'
     )
 
     for k, v in sensor_data.items():


### PR DESCRIPTION
pr for #221 

cleanup of metadata: typo fix, include pyglider version

cleanup of debug calls in binary_to_timeseries, so that deploymentyaml doesn't have to have pressure for get_glider_depth, or temp/conductivity/pressure for get_derived_eos_raw