### PR TITLE
Slocum OG1.0 GPS Fixes Update

### DIFF
--- a/pyglider/slocum.py
+++ b/pyglider/slocum.py
@@ -1044,17 +1044,30 @@ def binary_to_timeseries(
 
     ds = utils.fill_metadata(ds, deployment['metadata'], device_data, varnames=varnames)
 
-    # OG 1.0: add mandatory GPS fix variables on N_MEASUREMENTS dimension (sparse)
-    if deployment.get('output_dimension') == 'N_MEASUREMENTS':
+    # GPS fix variables: compute once, assign to all variables that specify
+    # processing_method: gps_fixes_from_nav.  Source columns and per-variable
+    # attributes come entirely from the YAML — no hard-coded trigger here.
+    gps_var_names = [
+        name for name, attrs in ncvar.items()
+        if isinstance(attrs, dict)
+        and isinstance(attrs.get('processing_method'), dict)
+        and 'gps_fixes_from_nav' in attrs['processing_method']
+    ]
+    if gps_var_names:
         try:
-            t_gps, lat_gps = dbd.get('m_gps_lat')
-            _, lon_gps = dbd.get('m_gps_lon')
+            # Use source columns from the first entry (they must all agree).
+            first_inputs = ncvar[gps_var_names[0]]['processing_method']['gps_fixes_from_nav'] or {}
+            lat_col = first_inputs.get('lat_source', 'm_gps_lat')
+            lon_col = first_inputs.get('lon_source', 'm_gps_lon')
+
+            t_gps, lat_gps = dbd.get(lat_col)
+            _, lon_gps = dbd.get(lon_col)
             valid = np.isfinite(lat_gps) & np.isfinite(lon_gps) & (lat_gps != 0) & (lon_gps != 0)
             t_gps = t_gps[valid]
             lat_gps = lat_gps[valid]
             lon_gps = lon_gps[valid]
 
-            # Map GPS fixes onto N_MEASUREMENTS time grid (NaN elsewhere)
+            # Map GPS fixes onto the sensor time grid (NaN elsewhere).
             n = len(ds['time'])
             ds_times_ns = ds['time'].values.astype(np.int64)
             gps_times_ns = (t_gps * 1e9).astype(np.int64)
@@ -1072,24 +1085,21 @@ def binary_to_timeseries(
                 lon_out[idx] = lon_gps[i]
                 t_out[idx] = t_gps[i]  # already in seconds since epoch
 
-            ds['LATITUDE_GPS'] = (('time',), lat_out, {
-                'long_name': 'latitude of each GPS location',
-                'standard_name': 'latitude',
-                'units': 'degrees_north',
-                'observation_type': 'measured',
-            })
-            ds['LONGITUDE_GPS'] = (('time',), lon_out, {
-                'long_name': 'longitude of each GPS location',
-                'standard_name': 'longitude',
-                'units': 'degrees_east',
-                'observation_type': 'measured',
-            })
-            ds['TIME_GPS'] = (('time',), t_out, {
-                'long_name': 'time of each GPS location',
-                'calendar': 'gregorian',
-                'units': 'seconds since 1970-01-01T00:00:00Z',
-                'observation_type': 'measured',
-            })
+            role_data = {'latitude': lat_out, 'longitude': lon_out, 'time': t_out}
+
+            for varname in gps_var_names:
+                inputs = ncvar[varname]['processing_method']['gps_fixes_from_nav'] or {}
+                role = inputs.get('role')
+                if role not in role_data:
+                    _log.warning('gps_fixes_from_nav: unknown role %r for %s; skipping', role, varname)
+                    continue
+                var_attrs = {k: v for k, v in ncvar[varname].items()
+                             if k not in ('processing_method', 'processing_role',
+                                          'average_method', 'source', 'coordinates')}
+                var_attrs = utils.fill_required_attrs(var_attrs)
+                ds[varname] = (('time',), role_data[role], var_attrs)
+
+
             n_gps = int(np.sum(np.isfinite(lat_out)))
             _log.info('Added %d GPS fixes as LATITUDE_GPS/LONGITUDE_GPS/TIME_GPS on N_MEASUREMENTS',
                       n_gps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ known-first-party = ["pyglider"]
 [tool.pixi.workspace]
 name = "pyglider"
 channels = ["conda-forge"]
-platforms = ["osx-arm64"]
+platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.pypi-dependencies]
 pyglider = { path = ".", editable = true }

--- a/tests/example-data/example-slocum/deploymentRealtime_og10.yml
+++ b/tests/example-data/example-slocum/deploymentRealtime_og10.yml
@@ -262,6 +262,45 @@ netcdf_variables:
         longitude: LONGITUDE
     long_name:     Distance over ground flown since mission start
     units:         km
+  
+  # -------------------------------------------------------------------------
+  # Sparse GPS fix variables (non-NaN only at actual surface fixes)
+  # -------------------------------------------------------------------------
+
+  LATITUDE_GPS:
+    processing_method:
+      gps_fixes_from_nav:
+        role:       latitude
+        lat_source: m_gps_lat
+        lon_source: m_gps_lon
+    long_name:     Latitude of each GPS surface fix
+    standard_name: latitude
+    units:         degrees_north
+    observation_type: measured
+    vocabulary:    http://vocab.nerc.ac.uk/collection/OG1/current/LAT/
+
+  LONGITUDE_GPS:
+    processing_method:
+      gps_fixes_from_nav:
+        role:       longitude
+        lat_source: m_gps_lat
+        lon_source: m_gps_lon
+    long_name:     Longitude of each GPS surface fix
+    standard_name: longitude
+    units:         degrees_east
+    observation_type: measured
+    vocabulary:    http://vocab.nerc.ac.uk/collection/OG1/current/LON/
+
+  TIME_GPS:
+    processing_method:
+      gps_fixes_from_nav:
+        role:       time
+        lat_source: m_gps_lat
+        lon_source: m_gps_lon
+    long_name:     Time of each GPS surface fix
+    calendar:      gregorian
+    units:         seconds since 1970-01-01T00:00:00Z
+    observation_type: measured
 
   # -------------------------------------------------------------------------
   # Derived thermodynamic variables (TEOS-10)


### PR DESCRIPTION
* Changed the Slocum processor for deriving `LATITUDE_GPS, LONGITUDE_GPS, TIME_GPS` to match how Seaexplorer does it (using the YAML).
* Added Linux-64 support in the project.toml

Something I also wanted to ask here, the yaml uses the processing method `gps_fixes_from_nav`. Since Slocum uses `m_gps_lat/lon` instead of `NavState` should the processing method name be more generic, like `gps_fixes`, or have slocum use a different name, maybe something like `gps_fixes_from_m_gps`,  or `gps_fixes_from_measured` 